### PR TITLE
fix: scope PDBeMolstar event listeners to container for Shadow DOM compatibility

### DIFF
--- a/src/ipymolstar/static/pdbemolstar.js
+++ b/src/ipymolstar/static/pdbemolstar.js
@@ -248,18 +248,18 @@ function render({ model, el }) {
     subscribe(model, name, callback)
   );
 
-  document.addEventListener("PDB.molstar.mouseover", (e) => {
+  viewerContainer.addEventListener("PDB.molstar.mouseover", (e) => {
     const eventData = e.eventData;
     model.set("mouseover_event", eventData);
     model.save_changes();
   });
 
-  document.addEventListener("PDB.molstar.mouseout", (e) => {
+  viewerContainer.addEventListener("PDB.molstar.mouseout", (e) => {
     model.set("mouseout_event", !model.get("mouseout_event") );
     model.save_changes();
   });
 
-  document.addEventListener("PDB.molstar.click", (e) => {
+  viewerContainer.addEventListener("PDB.molstar.click", (e) => {
     const eventData = e.eventData;
     model.set("click_event", eventData);
     model.save_changes();


### PR DESCRIPTION
Replace `document.addEventListener` with `viewerContainer.addEventListener` for mouseover, mouseout, and click events to fix interaction issues in Shadow DOM environments like marimo. This (partially) addresses the event propagation problems described in marimo-team/marimo#5204.
